### PR TITLE
[FLINK-4000] Fix for checkpoint state restore at MessageAcknowledgingSourceBase

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledgingSourceBase.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledgingSourceBase.java
@@ -127,8 +127,10 @@ public abstract class MessageAcknowledgingSourceBase<Type, UId>
 	@Override
 	public void open(Configuration parameters) throws Exception {
 		idsForCurrentCheckpoint = new ArrayList<>(64);
-		pendingCheckpoints = new ArrayDeque<>(numCheckpointsToKeep);
-		idsProcessedButNotAcknowledged = new HashSet<>();
+		if (pendingCheckpoints == null)
+			pendingCheckpoints = new ArrayDeque<>(numCheckpointsToKeep);
+		if (idsProcessedButNotAcknowledged == null)
+			idsProcessedButNotAcknowledged = new HashSet<>();
 	}
 
 	@Override
@@ -177,6 +179,7 @@ public abstract class MessageAcknowledgingSourceBase<Type, UId>
 
 	@Override
 	public void restoreState(SerializedCheckpointData[] state) throws Exception {
+		idsProcessedButNotAcknowledged = new HashSet<>();
 		pendingCheckpoints = SerializedCheckpointData.toDeque(state, idSerializer);
 		// build a set which contains all processed ids. It may be used to check if we have
 		// already processed an incoming message.


### PR DESCRIPTION
As says documentation for MessageAcknowledgingSourceBase.restoreState() 

This method is invoked when a function is executed as part of a recovery run. Note that restoreState() is called before open().

So current implementation
1. Fails on restoreState with NullPointerException, jobs fail to restart.
2. Does not restore anything because following open erases all checkpoint data immediately.
3. As consequence, violates exactly once rule because processed but not acknowledged list erased.

Proposed change fixes that.
